### PR TITLE
xenon-pci: refactor

### DIFF
--- a/arch/powerpc/platforms/xenon/pci.c
+++ b/arch/powerpc/platforms/xenon/pci.c
@@ -14,10 +14,12 @@
 
 #include <linux/kernel.h>
 #include <linux/pci.h>
+#include <linux/pci-ecam.h>
 #include <linux/delay.h>
 #include <linux/string.h>
 #include <linux/init.h>
 #include <linux/of.h>
+#include <linux/of_platform.h>
 
 #include <asm/sections.h>
 #include <asm/io.h>
@@ -29,284 +31,115 @@
 
 #include <asm/dma-mapping.h>
 
-#ifdef DEBUG
-#define DBG(x...) printk(x)
-#else
-#define DBG(x...)
-#endif
+#include "pci.h"
 
-#define OFFSET(bus, slot, func)	\
-	((((bus) << 8) + PCI_DEVFN(slot, func)) << 12)
+/* The Xenon's PCI controller supports modern ECAM PCIe configuration mechanism.
+ * Controllers like this are supposed to also support the legacy mechanism, so PPC Linux uses it,
+ * but if this one does, we don't know where it's mapped.
+ * Rough port of pci-ecam.c to confirm to the PowerPC PCI system.
+ */
 
-static int xenon_pci_read_config(struct pci_bus *bus, unsigned int devfn,
-			      int offset, int len, u32 *val)
+#define XENON_ECAM_MAXBUS 15
+
+static void __iomem *xenon_pci_ecam_map_bus(struct pci_bus *bus,
+					    unsigned int devfn, int where)
 {
-	struct pci_controller *hose;
+	unsigned int busn = bus->number;
 	unsigned int slot = PCI_SLOT(devfn);
 	unsigned int func = PCI_FUNC(devfn);
-	void* addr;
 
-	hose = pci_bus_to_host(bus);
+	struct pci_controller *hose = pci_bus_to_host(bus);
 	if (hose == NULL)
-		return PCIBIOS_DEVICE_NOT_FOUND;
+		return NULL;
 
-	DBG("xenon_pci_read_config, slot %d, func %d\n", slot, func);
+	if (busn < 0 || busn > 16)
+		return NULL;
 
-#if 0
-	if (PCI_SLOT(devfn) >= 32)
-		return PCIBIOS_DEVICE_NOT_FOUND;
-	if (PCI_SLOT(devfn) == 3)
-		return PCIBIOS_DEVICE_NOT_FOUND;
-	if (PCI_SLOT(devfn) == 6)
-		return PCIBIOS_DEVICE_NOT_FOUND;
-	if (PCI_SLOT(devfn) == 0xB)
-		return PCIBIOS_DEVICE_NOT_FOUND;
-	if (PCI_FUNC(devfn) >= 2)
-		return PCIBIOS_DEVICE_NOT_FOUND;
-#endif
-	DBG("xenon_pci_read_config, %p, devfn=%d, offset=%d, len=%d\n", bus, devfn, offset, len);
-
-	addr = ((void*)hose->cfg_addr) + offset;
-
-	/* map GPU to slot 0x0f */
-	if (slot == 0x0f)
-		addr += OFFSET(0, 0x02, func);
-	else
-		addr += OFFSET(1, slot, func);
-
-	/*
-	 * Note: the caller has already checked that offset is
-	 * suitably aligned and that len is 1, 2 or 4.
-	 */
-	switch (len) {
-	case 1:
-		*val = in_8((u8 *)addr);
-		break;
-	case 2:
-		*val = in_le16((u16 *)addr);
-		break;
-	default:
-		*val = in_le32((u32 *)addr);
-		break;
+	// HACK to remap the GPU onto bus 1. Should remove once Bus 0 is working.
+	if (busn == 1 && slot == 15) {
+		busn = 0;
+		slot = 2;
 	}
-	DBG("->%08x\n", (int)*val);
-	return PCIBIOS_SUCCESSFUL;
+
+	return ((void __iomem *)hose->cfg_addr) +
+	       PCIE_ECAM_OFFSET(busn, PCI_DEVFN(slot, func), where);
 }
 
-static int xenon_pci_write_config(struct pci_bus *bus, unsigned int devfn,
-			       int offset, int len, u32 val)
-{
-	struct pci_controller *hose;
-	unsigned int slot = PCI_SLOT(devfn);
-	unsigned int func = PCI_FUNC(devfn);
-	void *addr;
-
-	hose = pci_bus_to_host(bus);
-	if (hose == NULL)
-		return PCIBIOS_DEVICE_NOT_FOUND;
-
-	DBG("xenon_pci_write_config, slot %d, func %d\n", slot, func);
-
-	if (PCI_SLOT(devfn) >= 32)
-		return PCIBIOS_DEVICE_NOT_FOUND;
-#if 0
-	if (PCI_SLOT(devfn) == 3)
-		return PCIBIOS_DEVICE_NOT_FOUND;
-#endif
-	DBG("xenon_pci_write_config, %p, devfn=%d, offset=%x, len=%d, val=%08x\n", bus, devfn, offset, len, val);
-
-	addr = ((void*)hose->cfg_addr) + offset;
-
-	/* map GPU to slot 0x0f */
-	if (slot == 0x0f)
-		addr += OFFSET(0, 0x02, func);
-	else
-		addr += OFFSET(1, slot, func);
-
-	if (len == 4)
-		DBG("was: %08x\n", readl(addr));
-	if (len == 2)
-		DBG("was: %04x\n", readw(addr));
-	if (len == 1)
-		DBG("was: %02x\n", readb(addr));
-	/*
-	 * Note: the caller has already checked that offset is
-	 * suitably aligned and that len is 1, 2 or 4.
-	 */
-	switch (len) {
-	case 1:
-		writeb(val, addr);
-		break;
-	case 2:
-		writew(val, addr);
-		break;
-	default:
-		writel(val, addr);
-		break;
-	}
-	return PCIBIOS_SUCCESSFUL;
-}
-
-static struct pci_ops xenon_pci_ops =
-{
-	.read	= xenon_pci_read_config,
-	.write	= xenon_pci_write_config,
+static struct pci_ops xenon_pci_ops = {
+	.map_bus = xenon_pci_ecam_map_bus,
+	.read = pci_generic_config_read,
+	.write = pci_generic_config_write,
 };
 
-
-#if 1
-void __init xenon_pci_init(void)
+static int __init xenon_pci_probe(struct platform_device *pdev)
 {
+	struct device *dev = &pdev->dev;
+	struct device_node *dn = dev->of_node;
+
 	struct pci_controller *hose;
-	struct device_node *np, *root;
-	struct device_node *dev = NULL;
+	struct resource cfg_range;
+	u32 bus_range[2];
+	int err;
 
-	root = of_find_node_by_path("/");
-	if (root == NULL) {
-		printk(KERN_CRIT "xenon_pci_init: can't find root of device tree\n");
-		return;
-	}
-	for (np = NULL; (np = of_get_next_child(root, np)) != NULL;) {
-		if (np->name == NULL)
-			continue;
-		// printk("found node %p %s\n", np, np->name);
-		if (strcmp(np->name, "pci") == 0) {
-			of_node_get(np);
-			dev = np;
-		}
-	}
-	of_node_put(root);
-
-	if (!dev)
-	{
-		printk("couldn't find PCI node!\n");
-		return;
-	}
-
-	hose = pcibios_alloc_controller(dev);
-	if (hose == NULL)
-	{
+	hose = pcibios_alloc_controller(dn);
+	if (hose == NULL) {
 		printk("pcibios_alloc_controller failed!\n");
-		return;
-	}
-
-	hose->first_busno = 0;
-	hose->last_busno = 1;
-
-	hose->ops = &xenon_pci_ops;
-	hose->cfg_addr = ioremap(0xd0000000, 0x1000000);
-
-	pci_process_bridge_OF_ranges(hose, dev, 1);
-
-//	of_rescan_bus(root, ci_bus *bus)
-
-	/* Tell pci.c to not change any resource allocations.  */
-	pci_set_flags(PCI_PROBE_ONLY);
-
-	of_node_put(dev);
-	DBG("PCI initialized\n");
-
-	pci_io_base = 0;
-
-	// pcibios_scan_phb(hose, dev);
-	// Xbox 360 doesn't have IOMMU support. Who made this code?
-	// set_pci_dma_ops(&dma_direct_ops);
-}
-
-#else
-
-
-static int __init xenon_add_bridge(struct device_node *dev)
-{
-	int len;
-	struct pci_controller *hose;
-	struct resource rsrc;
-	char *disp_name;
-	const int *bus_range;
-	int primary = 1, has_address = 0;
-
-	printk(KERN_DEBUG "Adding PCI host bridge %s\n", dev->full_name);
-
-	/* Fetch host bridge registers address */
-	has_address = (of_address_to_resource(dev, 0, &rsrc) == 0);
-
-	/* Get bus range if any */
-	bus_range = of_get_property(dev, "bus-range", &len);
-	if (bus_range == NULL || len < 2 * sizeof(int)) {
-		printk(KERN_WARNING "Can't get bus-range for %s, assume"
-		       " bus 0\n", dev->full_name);
-	}
-
-	hose = pcibios_alloc_controller(dev);
-	if (!hose)
 		return -ENOMEM;
-	hose->first_busno = bus_range ? bus_range[0] : 0;
-	hose->last_busno = bus_range ? bus_range[1] : 0xff;
+	}
+	hose->parent = &pdev->dev;
 
+	err = of_property_read_u32_array(dn, "bus-range", bus_range,
+					 ARRAY_SIZE(bus_range));
+	if (err) {
+		bus_range[0] = 0;
+		bus_range[1] = XENON_ECAM_MAXBUS;
+	}
+
+	/*
+	 * TODO: Bus 0 has a P2P bridge on it that appears to run bus 1 for us. Unfortunately,
+	 * I can't get Linux resource allocation to work with it.. It's outside my wheelhouse.
+	 * For now, treat Bus 1 as the root and hack the GPU onto bus 1.
+	 */
+	hose->first_busno = 1; //bus_range[0];
+	hose->last_busno = XENON_ECAM_MAXBUS; //bus_range[1];
+
+	// todo this should really come from the DT "reg" or "cfg"
+	cfg_range.name = "PCI ECAM";
+	cfg_range.start = 0xd0000000;
+	cfg_range.end = cfg_range.start + PCIE_ECAM_BUS(hose->last_busno + 1);
+	cfg_range.flags = IORESOURCE_MEM;
+
+	hose->cfg_addr = devm_ioremap_resource(dev, &cfg_range);
+	if (IS_ERR(hose->cfg_addr)) {
+		dev_err(dev, "Failed to map ECAM - %ld\n",
+			PTR_ERR(hose->cfg_addr));
+		return PTR_ERR(hose->cfg_addr);
+	}
 	hose->ops = &xenon_pci_ops;
 
-	/* FIXME: should come from config */
-	hose->cfg_addr = ioremap(0xd0000000, 0x1000000);
+	pci_process_bridge_OF_ranges(hose, dn, 1);
 
-	disp_name = NULL;
-
-	printk(KERN_INFO "Found %s PCI host bridge at 0x%016llx. "
-	       "Firmware bus number: %d->%d\n",
-		disp_name, (unsigned long long)rsrc.start, hose->first_busno,
-		hose->last_busno);
-
-	printk(KERN_DEBUG " ->Hose at 0x%p, cfg_addr=0x%p,cfg_data=0x%p\n",
-		hose, hose->cfg_addr, hose->cfg_data);
-
-	/* Interpret the "ranges" property */
-	/* This also maps the I/O region and sets isa_io/mem_base */
-	pci_process_bridge_OF_ranges(hose, dev, primary);
-
-	/* Fixup "bus-range" OF property */
-	// fixup_bus_range(dev);
-
+	dev_info(dev, "PCI initialized\n");
 	return 0;
 }
 
 void __init xenon_pci_init(void)
 {
-	struct device_node *np, *root;
+	int found = 0;
+	struct device_node *dn;
+	struct platform_device *pdev;
 
-	ppc_pci_set_flags(PPC_PCI_CAN_SKIP_ISA_ALIGN);
-
-	root = of_find_node_by_path("/");
-	if (root == NULL) {
-		printk(KERN_CRIT "xenon_pci_init: can't find root "
-		       "of device tree\n");
+	for_each_compatible_node(dn, "pci", "xenon") {
+		pdev = of_platform_device_create(dn, "xenon-pci", NULL);
+		xenon_pci_probe(pdev);
+		found++;
+	}
+	if (!found) {
+		pr_warn("No PCI found!\n");
 		return;
 	}
-	for (np = NULL; (np = of_get_next_child(root, np)) != NULL;) {
-		if (np->name == NULL)
-			continue;
-		if (strcmp(np->name, "pci") == 0) {
-			if (xenon_add_bridge(np) == 0)
-				of_node_get(np);
-		}
-	}
-	of_node_put(root);
 
-	/* Setup the linkage between OF nodes and PHBs */
-	pci_devs_phb_init();
+	pr_info("Found %d instances\n", found);
 
-
-	/* We can allocate missing resources if any */
-	pci_probe_only = 0;
-	pci_probe_only = 1;
-
-	/* do we need that? */
-	pci_io_base = 0;
-
-	/* do we need that? */
-	ppc_md.pci_dma_dev_setup = NULL;
-	ppc_md.pci_dma_bus_setup = NULL;
-
-	// Xbox 360 doesn't have IOMMU support. Who made this code?
-	// set_pci_dma_ops(&dma_iommu_ops);
+	return;
 }
-
-#endif

--- a/arch/powerpc/platforms/xenon/pci.h
+++ b/arch/powerpc/platforms/xenon/pci.h
@@ -2,5 +2,6 @@
 #define XENON_PCI_H
 
 extern void __init xenon_pci_init(void);
+extern void xenon_pcibios_fixup_bus(struct pci_bus *bus);
 
 #endif

--- a/arch/powerpc/platforms/xenon/setup.c
+++ b/arch/powerpc/platforms/xenon/setup.c
@@ -68,7 +68,6 @@ static void __init xenon_setup_arch(void)
 	if (ROOT_DEV == 0)
 		ROOT_DEV = MKDEV(SCSI_DISK0_MAJOR, 1); // No mention of it being removed in root_dev.h? Why??
 
-	xenon_pci_init();
 #ifdef CONFIG_DUMMY_CONSOLE
 	conswitchp = &dummy_con;
 #endif
@@ -157,6 +156,7 @@ define_machine(xenon) {
 	.name			= "Xenon",
 	.probe			= xenon_probe,
 	.setup_arch		= xenon_setup_arch,
+	.discover_phbs		= xenon_pci_init,
 	.show_cpuinfo	= xenon_show_cpuinfo,
 	.calibrate_decr	= generic_calibrate_decr,
 	.init_IRQ       = xenon_init_irq,

--- a/drivers/xenon/smc-core.c
+++ b/drivers/xenon/smc-core.c
@@ -64,8 +64,8 @@ static void _xenon_smc_send(void *msg)
 {
 	unsigned long flags;
 
-	print_hex_dump(KERN_DEBUG, "_xenon_smc_send: ",
-		DUMP_PREFIX_NONE, 16, 2, msg, 16, 0);
+	// print_hex_dump(KERN_DEBUG, "_xenon_smc_send: ",
+	// 	DUMP_PREFIX_NONE, 16, 2, msg, 16, 0);
 
 	spin_lock_irqsave(&smc.fifo_lock, flags);
 	while (!(readl(smc.base + 0x84) & 4))
@@ -141,8 +141,8 @@ static void _xenon_smc_cache(unsigned char *msg) {
 	else
 		printk("unknown smc reply %02x", msg[0]);
 
-	print_hex_dump(KERN_DEBUG, "_xenon_smc_cache: ",
-		DUMP_PREFIX_NONE, 16, 2, msg, 16, 0);
+	//print_hex_dump(KERN_DEBUG, "_xenon_smc_cache: ",
+	//	DUMP_PREFIX_NONE, 16, 2, msg, 16, 0);
 	smc.cmd = msg[0];
 }
 
@@ -228,8 +228,8 @@ static irqreturn_t xenon_smc_irq(int irq, void *dev_id)
 
 	unsigned int irqs = readl(smc.base + 0x50);
 
-	printk(KERN_DEBUG "xenon_smc_irq() = %08x,%08x\n",
-		irqs, readl(smc.base + 0x94));
+	// printk(KERN_DEBUG "xenon_smc_irq() = %08x,%08x\n",
+	// 	irqs, readl(smc.base + 0x94));
 
 	if (irqs & 0x10000000) {
 		if (_xenon_smc_reply(msg)) {


### PR DESCRIPTION
Refactor the xenon PCI driver. I was hoping to use more of the generic code, but it turns out PPC Linux isn't really structured that way.

This code is *almost* able to expose the full PCI bus hierarchy (Bus 0 has a PCI bridge, the host bridge, and the GPU; Bus 1 has everything else) but I couldn't get resource allocation to work, so, like the old driver, I've limited it to Bus 1 for now and added a hack to get the GPU visible.